### PR TITLE
Fixed create -O option

### DIFF
--- a/create_option.go
+++ b/create_option.go
@@ -18,8 +18,8 @@ func Start(start time.Time) CreateOption {
 	return CreateOption(fmt.Sprintf("-b %v", start.Unix()))
 }
 
-// Overwrite returns a new create overwrite option.
-func Overwrite() CreateOption {
+// NoOverwrite returns a new create no overwrite option.
+func NoOverwrite() CreateOption {
 	return CreateOption("-O")
 }
 

--- a/create_option_test.go
+++ b/create_option_test.go
@@ -19,7 +19,7 @@ func TestCreateOption(t *testing.T) {
 		{"start", Start(now), fmt.Sprintf("-b %v", now.Unix())},
 		{"source", Source("test.rrd"), "-r test.rrd"},
 		{"template", Template("test.rrd"), "-t test.rrd"},
-		{"overwrite", Overwrite(), "-O"},
+		{"no-overwrite", NoOverwrite(), "-O"},
 	}
 
 	for _, tc := range tests {

--- a/errors.go
+++ b/errors.go
@@ -26,6 +26,12 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("%v (%v)", e.Msg, e.Code)
 }
 
+// IsExist returns true if err represents a failure due to a existing rrd, false otherwise.
+func IsExist(err error) bool {
+	err2, ok := err.(*Error)
+	return ok && err2.Code == -1 && strings.Contains(err2.Msg, "File exists")
+}
+
 // IsNotExist returns true if err represents a failure due to a non-existing rrd, false otherwise.
 func IsNotExist(err error) bool {
 	err2, ok := err.(*Error)

--- a/errors_test.go
+++ b/errors_test.go
@@ -29,6 +29,7 @@ func TestErrorHelpers(t *testing.T) {
 		err  error
 		f    func(error) bool
 	}{
+		{"exists", NewError(-1, "RRD Error: creating '/test.rrd': File exists"), IsExist},
 		{"not-exists", NewError(-1, "No such file: /test-missing.rrd"), IsNotExist},
 		{"illegal-update", NewError(-1, "illegal attempt to update using time 1499968801.000000 when last update time is 1499968801.000000 (minimum one second step)"), IsIllegalUpdate},
 	}


### PR DESCRIPTION
Despite its name -O to create is actually "no" overwrite so renamed Overwrite() to NoOverwrite().

Also added a IsExist error helper to detect an rrd exists error.