### PR TITLE
Support "-nan" value in Fetch command.

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -169,7 +169,7 @@ func (c *Client) Fetch(filename, cf string, options ...interface{}) (*Fetch, err
 			Data: make([]*float64, len(r.Names)),
 		}
 		for i, val := range strings.Split(strings.TrimSpace(parts[1]), " ") {
-			if val == "nan" {
+			if val == "nan" || val == "-nan" {
 				continue
 			}
 

--- a/mockserver_test.go
+++ b/mockserver_test.go
@@ -30,7 +30,7 @@ var (
 			"DSCount: 2",
 			"DSName: watts amps",
 			"1499909100: 8.00000000000000000e+00 1.73335123697916674e+03",
-			"1499909400: nan nan",
+			"1499909400: nan -nan",
 		},
 		"fetchbin": {
 			"7 Success",


### PR DESCRIPTION
Fetch can return both `nan` and `-nan` so add support for latter which was previously missing.